### PR TITLE
fix: add z-index to ensure close button remains clickable

### DIFF
--- a/_src/_assets/css/layout.scss
+++ b/_src/_assets/css/layout.scss
@@ -184,6 +184,7 @@ figure {
 	top: 0;
 	right: 1em;
 	cursor: pointer;
+	z-index: 1;
 	&:after {
 		content: "×";
 		color: rgba(255,255,255,.7);


### PR DESCRIPTION
Hi Mat 👋 

I was reading Chris Coyier's [Practical SVG](https://practical-svg.chriscoyier.net/) earlier, and noticed an issue where the button to close the modal was blocked by the link item margin:

<img width="497" alt="Google developer tools showing the margin of the first link item blocking the close modal button" src="https://github.com/user-attachments/assets/1fc85e3e-a0e9-4a54-85c7-c9b03d703ab6">

I opened [a PR](https://github.com/chriscoyier/practical-svg/pull/1/files) to resolve it on Chris' site, but figured it would make sense to contribute back to the original template in case it would be useful. Thanks for the awesome tool (lovely to see Eleventy in use as well!).