### PR TITLE
Update type.scss

### DIFF
--- a/_src/_assets/css/type.scss
+++ b/_src/_assets/css/type.scss
@@ -220,6 +220,7 @@ figcaption {
 	line-height: .85;
 	margin: 0;
 	padding: 0;
+	text-shadow: 0 0 1em #FFF5;
 }
 .chapter-num {
 	font-family: "League Gothic", sans-serif;


### PR DESCRIPTION
Added a faint `text-shadow` smear around chapter titles so books with dark backgrounds colors don’t have the chapter titles fade away